### PR TITLE
Feature/dns resolvconf extension

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -24,4 +24,9 @@ config :nerves_network, :dhclient,
     pid_file:   "/root/dhclient6.pid"
   ]
 
+config :nerves_network, :resolver,
+  [
+    resolvconf_file: "/tmp/resolv.conf"
+  ]
+
 

--- a/lib/nerves_network.ex
+++ b/lib/nerves_network.ex
@@ -25,7 +25,10 @@ defmodule Nerves.Network do
     {:ipv4_address, Types.ip_address} |
     {:ipv4_subnet_mask, Types.ip_address} |
     {:domain, String.t} |
+    {:search, String.t} |
+    {:static_domains, list(String.t)} |
     {:nameservers, [Types.ip_address]} |
+    {:ipv6_nameservers, [Types.ip_address]} |
     {:ssid, String.t} |
     {:key_mgmt, :"WPA-PSK" | :NONE} |
     {:psk, String.t}

--- a/lib/nerves_network/application.ex
+++ b/lib/nerves_network/application.ex
@@ -6,10 +6,12 @@ defmodule Nerves.Network.Application do
   def start(_type, _args) do
     import Supervisor.Spec, warn: false
 
+    [resolvconf_file: resolvconf_file] = Application.get_env(:nerves_network, :resolver, [])
+
     children = [
       supervisor(Registry, [:duplicate, Nerves.Udhcpc], id: Nerves.Udhcpc),
       supervisor(Registry, [:duplicate, Nerves.Dhclient], id: Nerves.Dhclient),
-      worker(Nerves.Network.Resolvconf, ["/tmp/resolv.conf", [name: Nerves.Network.Resolvconf]]),
+      worker(Nerves.Network.Resolvconf, [resolvconf_file, [name: Nerves.Network.Resolvconf]]),
       supervisor(Nerves.Network.IFSupervisor, [[name: Nerves.Network.IFSupervisor]]),
       worker(Nerves.Network.Config, []),
     ]

--- a/lib/nerves_network/resolvconf.ex
+++ b/lib/nerves_network/resolvconf.ex
@@ -232,14 +232,15 @@ defmodule Nerves.Network.Resolvconf do
   defp domain_text({_ifname, ifmap = %{:static_domains => static_domains}}) when is_list(static_domains) and static_domains != nil do
     ipv4_domain_string    = ifmap[:domain] || ""
     ipv6_domain_string    = ifmap[:ipv6_domain] || ""
-    case static_domains do
-      [] -> static_domains_string = Enum.join(static_domains, " ")
+    if static_domains != [] do
+      static_domains_string = Enum.join(static_domains, " ")
         "search  #{static_domains_string}"
          |> append_domain(ipv4_domain_string)
-          |> append_domain(ipv6_domain_string)
+         |> append_domain(ipv6_domain_string)
          |> String.trim()
          |> append_domain("\n")
-      _ -> ""
+      else
+      ""
     end
   end
   defp domain_text({_ifname, %{:domain => domain, :ipv6_domain => ipv6_domain}}) when domain != "" or ipv6_domain != "", do: "search #{domain} #{ipv6_domain}\n"

--- a/lib/nerves_network/resolvconf.ex
+++ b/lib/nerves_network/resolvconf.ex
@@ -17,8 +17,8 @@ defmodule Nerves.Network.Resolvconf do
   @type ifmap :: %{
     domain: String.t,
     search: String.t,
-    nameservers: [Types.ip_address]
-    static_nameservers: [Types.ip_address]
+    nameservers: [Types.ip_address],
+    static_nameservers: [Types.ip_address],
     ipv6_nameservers: [Types.ip_address]
   }
 


### PR DESCRIPTION
The extension for obtaining the resolver's settings.
Other extensions i.e. adding static DNS settings are on the way. Prefer to review in smaller chunks.