### PR TITLE
Fixing the DHCPv6 stateless

### DIFF
--- a/lib/nerves_network/dhclient.ex
+++ b/lib/nerves_network/dhclient.ex
@@ -170,6 +170,14 @@ defmodule Nerves.Network.Dhclient do
     {:reply, :ok, state}
   end
 
+  def handle_info({_pid, {:exit_status, exit_status = 0}}, state) do
+    Logger.info(
+      "dhclient exited exit_status = #{inspect(exit_status)}, state = #{inspect(state)}"
+    )
+
+    {:stop, :normal, %{state | running: false}}
+  end
+
   #  Nerves.Network.Dhclient.handle_info({#Port<0.6423>, {:exit_status, 0}}, %{ifname: "eth1", port: #Port<0.6423>})
   def handle_info({_pid, {:exit_status, exit_status}}, state) do
     Logger.error(

--- a/lib/nerves_network/dhcpv6_manager.ex
+++ b/lib/nerves_network/dhcpv6_manager.ex
@@ -295,9 +295,16 @@ defmodule Nerves.Network.DHCPv6Manager do
     state
   end
 
+  defp translate_ipv6_address(info = %{ipv6_address: ""}) do
+    Map.drop(info, [:ipv6_address])
+  end
+
+  defp translate_ipv6_address(info) do
+    info
+  end
+
   defp setup_iface(state, info) do
-    #state = start_link_local(state)
-    case Nerves.NetworkInterface.setup(state.ifname, info) do
+    case Nerves.NetworkInterface.setup(state.ifname, translate_ipv6_address(info)) do
       :ok -> :ok
       {:error, :eexist} -> :ok
         #It may very often happen that at the renew time we would receive the lease of the very same IP address...

--- a/lib/nerves_network/if_supervisor.ex
+++ b/lib/nerves_network/if_supervisor.ex
@@ -19,6 +19,14 @@ defmodule Nerves.Network.IFSupervisor do
     {:ok, {{:one_for_one, 10, 3600}, []}}
   end
 
+  defp restart_type(_manager = Nerves.Network.DHCPv6Manager) do
+    :transient
+  end
+
+  defp restart_type(_manager) do
+    :permanent
+  end
+
   @spec setup(Types.ifname | atom, Nerves.Network.setup_settings) :: Supervisor.on_start_child()
   def setup(ifname, settings) when is_atom(ifname) do
     log_atomized_iface_error(ifname)
@@ -32,7 +40,7 @@ defmodule Nerves.Network.IFSupervisor do
     children =
       for manager <- manager_modules  do
         child_name = pname(ifname, manager)
-        worker(manager, [ifname, settings, [name: child_name]], id: {pname(ifname), child_name})
+        worker(manager, [ifname, settings, [name: child_name]], [id: {pname(ifname), child_name}, restart: restart_type(manager)])
       end
     Logger.debug fn -> "#{__MODULE__} children: #{inspect children}" end
 


### PR DESCRIPTION
Fixing a bug in processing the network interface's set-up coming from the stateless DHCPv6 client (ipv6_address = "")
+
The exit of the DHCPv6 client with the code 0 (O.K.) not to be reason for the restart of the worker child