### PR TITLE
Bugfix/resolv conf multi sourcing ipv4 ipv6 static

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -30,7 +30,7 @@ config :nerves_network, :dhclientv4,
   ipv4: [
     lease_file:        "/root/dhclient4.leases",
     pid_file:          "/root/dhclient4.pid",
-    config_file:       "/root/dhclient4.conf"
+    config_file:       "/root/dhclient4.conf",
     flush_resolv_conf: false # At network interface down event clear resolver configuration held in resolv.conf
   ]
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -20,16 +20,18 @@ config :nerves_network, :default,
 #i.e. dhclient6.leases.eth0
 config :nerves_network, :dhclientv6,
   ipv6: [
-    lease_file:  "/root/dhclient6.leases",
-    pid_file:    "/root/dhclient6.pid",
-    config_file: "/root/dhclient6.conf"
+    lease_file:        "/root/dhclient6.leases",
+    pid_file:          "/root/dhclient6.pid",
+    config_file:       "/root/dhclient6.conf",
+    flush_resolv_conf: false # At network interface down event clear resolver configuration held in resolv.conf
   ]
 
 config :nerves_network, :dhclientv4,
   ipv4: [
-    lease_file:  "/root/dhclient4.leases",
-    pid_file:    "/root/dhclient4.pid",
-    config_file: "/root/dhclient4.conf"
+    lease_file:        "/root/dhclient4.leases",
+    pid_file:          "/root/dhclient4.pid",
+    config_file:       "/root/dhclient4.conf"
+    flush_resolv_conf: false # At network interface down event clear resolver configuration held in resolv.conf
   ]
 
 config :nerves_network, :resolver,

--- a/lib/nerves_network/dhclientv4.ex
+++ b/lib/nerves_network/dhclientv4.ex
@@ -320,9 +320,7 @@ defmodule Nerves.Network.Dhclientv4 do
 
   # Handling informational debug prints from the dhclient
   defp handle_dhclient([message], state) do
-    Logger.debug(
-      "#{__MODULE__} handle_dhclient args = #{inspect(message)} state = #{inspect(state)}"
-    )
+    Logger.debug("handle_dhclient args = #{inspect(message)} state = #{inspect(state)}")
 
     {:noreply, state}
   end


### PR DESCRIPTION
Hello All,

This is fixing the /etc/resolv.conf management:
1. We now are avoiding empty entries like
    _**nameserver**_
that were occurring when a DHCP server sent us only one name-server instead of two.

2. We are as well now handling correctly the domain search string that was failing to be added when a DHCP server (be it IPv4 or IPv6) sent us a list of domain searches instead of just one domain.

With my best wishes
     Tomasz Motyl