### PR TITLE
Adding support for the TIMEOUT DHCPv4 event so it shall use the last …

### DIFF
--- a/lib/nerves_network/dhclientv4.ex
+++ b/lib/nerves_network/dhclientv4.ex
@@ -253,10 +253,17 @@ defmodule Nerves.Network.Dhclientv4 do
     {:noreply, state}
   end
 
-  defp handle_dhclient([reason | _options], state) when reason in ["MEDIUM", "ARPCHECK", "ARPSEND", "TIMEOUT"] do
-    Logger.debug(
-      "dhclientv4: Received reason '#{reason}'. Not performing any update to network interface."
-    )
+  #[debug] Nerves.Network.Dhclientv4.handle_dhclient/2 : Received reason 'TIMEOUT; options = ["eth0", "10.216.251.86", "10.216.251.127", "255.255.255.128", "10.216.251.1", "eur.gad.schneider-electric.com", "10.156.118.9 10.198.90.15"]'. Not performing any update to network interface.
+  defp handle_dhclient([reason | options], state) when reason in ["MEDIUM", "ARPCHECK", "ARPSEND"] do
+    Logger.debug("Received reason '#{reason}; options = #{inspect options}'. Not performing any update to network interface.")
+
+    {:noreply, state}
+  end
+
+  defp handle_dhclient([reason = "TIMEOUT" | options], state) do
+    Logger.debug("dhclientv4: Received reason '#{reason}'")
+
+    notify(options, :bound, state)
 
     {:noreply, state}
   end


### PR DESCRIPTION
…valid lease in the case of lack of DHCP offers.

We align with the /sbin/dhclient-script by ISC. Ane xcerpt below:

367     TIMEOUT)
368         if [ -n "$alias_ip_address" ]; then
369             # flush alias IP
370             ip -4 addr flush dev ${interface} label ${interface}:0
371         fi
372 
373         # set IP from recorded lease
374         ip -4 addr add ${new_ip_address}${new_subnet_mask:+/$new_subnet_mask} \
375             ${new_broadcast_address:+broadcast $new_broadcast_address} \
376             dev ${interface} label ${interface}
377 
......
