### PR TITLE
Devel/adding default prefix length configuration option

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -23,6 +23,7 @@ config :nerves_network, :dhclientv6,
     lease_file:        "/root/dhclient6.leases",
     pid_file:          "/root/dhclient6.pid",
     config_file:       "/root/dhclient6.conf",
+    # default_prefix_length: 64,
     flush_resolv_conf: false # At network interface down event clear resolver configuration held in resolv.conf
   ]
 

--- a/lib/nerves_network/dhclient.ex
+++ b/lib/nerves_network/dhclient.ex
@@ -108,7 +108,7 @@ defmodule Nerves.Network.Dhclient do
 
   # Starting from ISC dhclient v4.4.1 the default prefix length can be specified. If it is not
   # The default value is 128. Changed from 64 used in previous revisions.
-  defp runtime_default_prefix_length(ifname, runtime) do
+  defp runtime_default_prefix_length(_ifname, runtime) do
     if Keyword.has_key?(runtime, :default_prefix_length) do
       ["--address-prefix-len", "#{Keyword.get(runtime, :default_prefix_length)}"]
     else

--- a/lib/nerves_network/dhclientv4.ex
+++ b/lib/nerves_network/dhclientv4.ex
@@ -317,7 +317,15 @@ defmodule Nerves.Network.Dhclientv4 do
     {:noreply, state}
   end
 
-  defp handle_dhclient([reason | options], state) when reason in ["FAIL", "RELEASE", "STOP"] do
+  defp handle_dhclient([reason | options], state) when reason in ["FAIL"] do
+    Logger.debug("dhclientv4: Received reason '#{reason}'.")
+
+    notify(options, :leasefail, state)
+
+    {:noreply, state}
+  end
+
+  defp handle_dhclient([reason | options], state) when reason in ["RELEASE", "STOP"] do
     Logger.debug("dhclientv4: Received reason '#{reason}'. Bringing interface down.")
 
     notify(options, :ifdown, state)

--- a/lib/nerves_network/dhcp_manager.ex
+++ b/lib/nerves_network/dhcp_manager.ex
@@ -114,6 +114,13 @@ defmodule Nerves.Network.DHCPManager do
     {:noreply, s}
   end
 
+  def handle_info(event = :dhcp_retry, s = %{ifname: ifname}) do
+    Logger.debug("DHCPManager.EventHandler(#{ifname}) dhcp_retry; state = #{inspect s}")
+    s = consume(s.context, event, s)
+    {:noreply, s}
+  end
+
+
   def handle_info(event, s) do
     Logger.debug("DHCPManager.EventHandler(#{s.ifname}): ignoring event: #{inspect(event)}")
     {:noreply, s}

--- a/mix.lock
+++ b/mix.lock
@@ -1,8 +1,9 @@
 %{
   "dialyxir": {:hex, :dialyxir, "0.5.1", "b331b091720fd93e878137add264bac4f644e1ddae07a70bf7062c7862c4b952", [:mix], [], "hexpm"},
   "earmark": {:hex, :earmark, "1.2.3", "206eb2e2ac1a794aa5256f3982de7a76bf4579ff91cb28d0e17ea2c9491e46a4", [:mix], [], "hexpm"},
-  "elixir_make": {:hex, :elixir_make, "0.5.2", "96a28c79f5b8d34879cd95ebc04d2a0d678cfbbd3e74c43cb63a76adf0ee8054", [:mix], [], "hexpm"},
+  "elixir_make": {:hex, :elixir_make, "0.6.0", "38349f3e29aff4864352084fc736fa7fa0f2995a819a737554f7ebd28b85aaab", [:mix], [], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.16.2", "3b3e210ebcd85a7c76b4e73f85c5640c011d2a0b2f06dcdf5acdb2ae904e5084", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
+  "muontrap": {:hex, :muontrap, "0.3.1", "c157f5367b73f39efd2cf12da0ac55b8454add1798f35a1d763a6bdb3ae70e31", [:make, :mix], [{:elixir_make, "~> 0.4", [hex: :elixir_make, repo: "hexpm", optional: false]}], "hexpm"},
   "nerves_network_interface": {:hex, :nerves_network_interface, "0.4.6", "d50e57daca8154f0f780fd98eb5ae94a005579e0d72d69840e80e228375d88ad", [:make, :mix], [{:elixir_make, "~> 0.5", [hex: :elixir_make, repo: "hexpm", optional: false]}], "hexpm"},
   "nerves_wpa_supplicant": {:hex, :nerves_wpa_supplicant, "0.3.2", "19dc7e1248336e7f542b11b2b857ceb5b088d3eb41a6ca75b7b76628dcf67aad", [:make, :mix], [{:elixir_make, "~> 0.3", [hex: :elixir_make, repo: "hexpm", optional: false]}], "hexpm"},
   "system_registry": {:hex, :system_registry, "0.4.0", "d8a7267005418efd8291df327153ae6f11badcb7a8827dd00ed59dc9abb3f9a6", [:mix], [], "hexpm"},


### PR DESCRIPTION
1.  Fixing DHCPv4 lease fail
2. Adding backwards-compatibility configuration option 'default_prefix_length' to be used with ISC DHCP -6 daemon of version 4.4.1+