### PR TITLE
When attempting to contact gateway with irresponsive DHCP server - li…

### DIFF
--- a/lib/nerves_network/dhcp_manager.ex
+++ b/lib/nerves_network/dhcp_manager.ex
@@ -217,7 +217,7 @@ defmodule Nerves.Network.DHCPManager do
   end
 
   defp deconfigure_if_gateway_not_pingable(state, info = %{ipv4_gateway: ipv4_gateway}) do
-    System.cmd("ping", ["-c", "1", "-q", ipv4_gateway])
+    System.cmd("ping", ["-c", "1", "-q", "-t", "1", ipv4_gateway])
     |> deconfigure_if_gateway_not_pingable(state, info)
   end
 


### PR DESCRIPTION
…miting number of hops to 1

This is an overlook. The gateway from outside the sub-net the NMC4 card is plugged into may respond to an ICMP echo, hence giving the NMC wrong impression of being connected to this particular network.  The ping command parameters were originally copied from dhclient-script by the open-source community and they definitely are not aware of this lil-'bug' yet ;)