### PR TITLE
Replace Process.info/1 with Process.info/2

### DIFF
--- a/lib/nerves_network/dhclientv4.ex
+++ b/lib/nerves_network/dhclientv4.ex
@@ -70,7 +70,7 @@ defmodule Nerves.Network.Dhclientv4 do
   def stop(pid, reason \\ :unknown) do
     Logger.debug("Dhclientv4.stop pid: #{inspect(pid)}; reason = #{inspect reason}")
 
-    Process.info(pid)
+    Process.info(pid, [:reductions, :memory, :message_queue_len])
     |> do_stop(pid, reason)
   end
 


### PR DESCRIPTION
Process.info/1 should never be used in production, or even development. It should be used for debugging purposes only.

The reason being is that the iex_history attribute grows exponentially everytime this function gets call called. It is effectively a memory leak, as the iex_history contains maps that get more and more nested at each call.

Erlang even warn against this: https://www.erlang.org/doc/man/erlang.html#process_info-1